### PR TITLE
support laravel 9 and lumen 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
         "custom command"
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/config": "~6.0|~7.0|~8.0",
-        "illuminate/filesystem": "~6.0|~7.0|~8.0",
-        "spatie/data-transfer-object": "^1.3|^2.8"
+        "php": "^8.0",
+        "illuminate/console": "~9.0",
+        "illuminate/support": "~9.0",
+        "illuminate/config": "~9.0",
+        "illuminate/filesystem": "~9.0",
+        "spatie/data-transfer-object": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",


### PR DESCRIPTION
1. PHP
- require 8+
- drop support for 7.x
2. illuminate/console
- require 9+
- drop support for 6+ & 7+
3. illuminate/support
- require 9+
- drop support for 6+ & 7+
4. spatie/data-transfer-object
- require 3.7+
- drop support for 1.3+ & 2.8+
